### PR TITLE
Add config file for Kitty terminal

### DIFF
--- a/Kitty/Daemon-2.0.conf
+++ b/Kitty/Daemon-2.0.conf
@@ -1,0 +1,47 @@
+#: Daemon-2.0 Theme for Kitty Terminal
+
+foreground              #5df4fe
+background              #210e15
+selection_foreground    #210e15
+selection_background    #5df4fe
+
+#: Cursor
+cursor                  #5df4fe
+cursor_text_color       #210e15
+
+#: Standard colors
+# black
+color0  #200d14  
+# red
+color1  #fb3048  
+# green
+color2  #1ac5b0  
+# yellow
+color3  #fdf500  
+# blue
+color4  #9370db  
+# magenta
+color5  #cb1dcd  
+# cyan
+color6  #ff5048  
+# white
+color7  #28c775  
+
+#: Bright colors
+# bright black
+color8   #ffffff  
+# bright red
+color9   #fb3048  
+# bright green
+color10  #1ac5b0  
+# bright yellow
+color11  #fdf500  
+# bright blue
+color12  #9370db  
+# bright magenta
+color13  #cb1dcd  
+# bright cyan
+color14  #ff5048  
+# bright white
+color15  #28c775  
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cp -r 'Plasma Style/Daemon-2.0' $HOME/.local/share/plasma/desktoptheme/
 cp -r 'Window Decorations/daemon-2.0' $HOME/.local/share/aurorae/themes/
 cp Konsole/Daemon-2.0.colorscheme $HOME/.local/share/konsole/
 cp -r VSCode/daemon-2.0 $HOME/.vscode-oss/extensions/
+cp Kitty/Daemon-2.0.conf $HOME/.config/kitty/
 ```
 
 ### Pling store


### PR DESCRIPTION
This PR adds a `.conf` file for Kitty terminal.
Note that in order for it to work, you need to add `include Daemon-2.0.conf` in your `kitty.conf`. I wasn't sure where (or if) to add this comment in the repo, so I am mentioning it here.